### PR TITLE
Refactor to simplify code

### DIFF
--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -12,17 +12,13 @@ $tests = Invoke-ScriptAnalyzer -Path /github/workspace -Settings PSGallery -Recu
 foreach ($test in $tests)
 {
 
-    $Severity = $test.Severity
-    $Message = $test.Message
-    $Line = $test.Line
-
     if ($Severity -like "*Error*")
     {
 
         $errorHash = @{
-            Severity = $Severity
-            Message  = $Message
-            Line     = $Line
+            Severity = $($test.Severity)
+            Message  = $($test.Message)
+            Line     = $($test.Line)
         }
 
         $errorOutput = New-Object -TypeName System.Management.Automation.PSObject -Property $errorHash

--- a/entrypoint.ps1
+++ b/entrypoint.ps1
@@ -12,7 +12,7 @@ $tests = Invoke-ScriptAnalyzer -Path /github/workspace -Settings PSGallery -Recu
 foreach ($test in $tests)
 {
 
-    if ($Severity -like "*Error*")
+    if ($($test.Severity) -like "*Error*")
     {
 
         $errorHash = @{


### PR DESCRIPTION
You don't need to re-declare variables to pull them out of an object. You can just call them directly. I used to do that, too, until I learned this method.